### PR TITLE
[BUGFIX] Trigger page tree reload after changing URL path segment

### DIFF
--- a/Classes/MOC/SynchronizeUrl/Package.php
+++ b/Classes/MOC/SynchronizeUrl/Package.php
@@ -32,7 +32,7 @@ class Package extends BasePackage {
 					$node->setProperty('uriPathSegment', $newUriPathSegment);
 					$newUriPathSegment = NULL;
 				}
-                $bootstrap->getObjectManager()->get('TYPO3\Neos\Routing\Cache\RouteCacheFlusher')->registerNodeChange($node);
+				$bootstrap->getObjectManager()->get('TYPO3\Neos\Routing\Cache\RouteCacheFlusher')->registerNodeChange($node);
 			}
 		});
 	}

--- a/Classes/MOC/SynchronizeUrl/Package.php
+++ b/Classes/MOC/SynchronizeUrl/Package.php
@@ -26,8 +26,14 @@ class Package extends BasePackage {
 				$node->setProperty('uriPathSegment', $newUriPathSegment);
 				$bootstrap->getObjectManager()->get('TYPO3\Neos\Routing\Cache\RouteCacheFlusher')->registerNodeChange($node);
 			} elseif ($propertyName === 'uriPathSegment' && $newUriPathSegment !== NULL && $newValue !== $newUriPathSegment) {
-				$node->setProperty('uriPathSegment', $newUriPathSegment);
-				$newUriPathSegment = NULL;
+				if (method_exists('TYPO3\Neos\Utility\NodeUriPathSegmentGenerator', 'setUniqueUriPathSegment')) {
+					NodeUriPathSegmentGenerator::setUniqueUriPathSegment($node);
+					$bootstrap->getObjectManager()->get('TYPO3\Neos\Routing\Cache\RouteCacheFlusher')->registerNodeChange($node);
+				} else {
+					$node->setProperty('uriPathSegment', $newUriPathSegment);
+					$bootstrap->getObjectManager()->get('TYPO3\Neos\Routing\Cache\RouteCacheFlusher')->registerNodeChange($node);
+					$newUriPathSegment = NULL;
+				}
 			}
 		});
 	}

--- a/Classes/MOC/SynchronizeUrl/Package.php
+++ b/Classes/MOC/SynchronizeUrl/Package.php
@@ -28,12 +28,11 @@ class Package extends BasePackage {
 			} elseif ($propertyName === 'uriPathSegment' && $newUriPathSegment !== NULL && $newValue !== $newUriPathSegment) {
 				if (method_exists('TYPO3\Neos\Utility\NodeUriPathSegmentGenerator', 'setUniqueUriPathSegment')) {
 					NodeUriPathSegmentGenerator::setUniqueUriPathSegment($node);
-					$bootstrap->getObjectManager()->get('TYPO3\Neos\Routing\Cache\RouteCacheFlusher')->registerNodeChange($node);
 				} else {
 					$node->setProperty('uriPathSegment', $newUriPathSegment);
-					$bootstrap->getObjectManager()->get('TYPO3\Neos\Routing\Cache\RouteCacheFlusher')->registerNodeChange($node);
 					$newUriPathSegment = NULL;
 				}
+                $bootstrap->getObjectManager()->get('TYPO3\Neos\Routing\Cache\RouteCacheFlusher')->registerNodeChange($node);
 			}
 		});
 	}


### PR DESCRIPTION
Previously, the page tree in Neos 2.3 was not reloaded after changing
the URL path segment, which lead to errors in the backend.

See #3