### PR TITLE
BUGFIX: Generate unique uriPathSegment if target segment already exists

### DIFF
--- a/Classes/MOC/SynchronizeUrl/Package.php
+++ b/Classes/MOC/SynchronizeUrl/Package.php
@@ -27,6 +27,22 @@ class Package extends BasePackage
                 if ($propertyName === 'title' && $node->getNodeType()->isOfType('Neos.Neos:Document')) {
                     $nodeUriPathSegmentGenerator = $bootstrap->getObjectManager()->get(NodeUriPathSegmentGenerator::class);
                     $newUriPathSegment = strtolower($nodeUriPathSegmentGenerator->generateUriPathSegment($node));
+
+                    $uriPathSegmentsOnLevel = [];
+                    foreach ($node->getParent()->getChildNodes() as $childNode) {
+                        if ($childNode->getIdentifier() === $node->getIdentifier()) {
+                            continue;
+                        }
+                        $uriPathSegmentsOnLevel[] = $childNode->getProperty('uriPathSegment');
+                    }
+
+                    $increments = 1;
+                    $originalNewUriPathSegment = $newUriPathSegment;
+                    while(in_array($newUriPathSegment, $uriPathSegmentsOnLevel)) {
+                        $newUriPathSegment = $originalNewUriPathSegment . '-' . $increments;
+                        $increments++;
+                    }
+
                     $node->setProperty('uriPathSegment', $newUriPathSegment);
                     $bootstrap->getObjectManager()->get(RouteCacheFlusher::class)->registerNodeChange($node);
                 } elseif ($propertyName === 'uriPathSegment' && $newUriPathSegment !== null && $newValue !== $newUriPathSegment) {


### PR DESCRIPTION
Given you name a new or existing page the same as another page is named already..
you end up with two different nodes which have the identical uriPathSegment and only one is accessible.

A real world example was, where a client had a hideInMenu node named "News" with the actual news document childnodes in it.
And then the client created a Shortcut named "News" with target to the home.

An alternative but outdated implementation you find in #2 
Would be great to see this fixed :+1: 